### PR TITLE
Export `Props` type as `ReactSlidingPaneProps`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.2.0",
   "description": "Full height sliding pane",
   "main": "dist/react-sliding-pane.js",
+  "types": "dist/react-sliding-pane.d.ts",
   "files": [
     "dist/*"
   ],

--- a/src/react-sliding-pane.tsx
+++ b/src/react-sliding-pane.tsx
@@ -147,4 +147,5 @@ function IconClose() {
   );
 }
 
+export type { Props as ReactSlidingPaneProps };
 export default ReactSlidingPane;

--- a/src/react-sliding-pane.tsx
+++ b/src/react-sliding-pane.tsx
@@ -8,7 +8,7 @@ import "./react-sliding-pane.css";
 
 const CLOSE_TIMEOUT = 500;
 
-type Props = {
+type ReactSlidingPaneProps = {
   isOpen?: boolean;
   title?: React.ReactNode;
   subtitle?: React.ReactNode;
@@ -67,7 +67,7 @@ export function ReactSlidingPane({
   width,
   shouldCloseOnEsc,
   hideHeader = false,
-}: Props) {
+}: ReactSlidingPaneProps) {
   const directionClass = `slide-pane_from_${from}`;
 
   // Not usign array destruction to reduce bundle size by not introducing polyfill
@@ -147,5 +147,5 @@ function IconClose() {
   );
 }
 
-export type { Props as ReactSlidingPaneProps };
+export type { ReactSlidingPaneProps };
 export default ReactSlidingPane;


### PR DESCRIPTION
I need to create wrapper components for `ReactSlidingPane` thus I need to access its props type .